### PR TITLE
README: use git format-patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,36 +32,107 @@ openssl rsa -in retiolum-cfg/retiolum.rsa_key.priv -pubout -out retiolum-cfg/ret
 
 ## add key to stockholm
 
+The stockholm repository contains (among other things) the configuration of the
+retiolum super nodes.  This configuration needs to be updated in order to add
+new hosts to the network.
+
+Checkout the repository and change into it:
+
 ```
 git clone https://cgit.krebsco.de/stockholm
+cd stockholm
 ```
 
-choose an ipv4 address in the range of 10.243.0.0/16
-check if the ipv4 address is already used by anyone in stockholm:
+Choose an IPv4 address in the range of 10.243.0.0/16, and check whether it is
+already occupied:
 
 ```
-git -C stockholm grep 10.243.my.ip
+git grep 10.243.my.ip
 ```
 
-modify the default.nix in krebs/3modules/external
+Add your user and host information to krebs/3modules/external/default.nix while
+preserving lexicographical order of the entries.  The most important bits to
+configure are the `owner` and the `nets.retiolum` attributes.  Have a look at
+e.g. the `matchbox` host to see a minimal example:
 
 ```
-vim krebs/3modules/external/default.nix
+$EDITOR krebs/3modules/external/default.nix
 ```
 
-add your host nix information to this file, please mind the alphabetical sorting
-
-now, create a patch out of your changes:
+Prepare a pull-request:
 
 ```
-git diff > retiolum.patch
-````
+git add krebs/3modules/external/default.nix
+git commit -m 'external: add myhostname'
+git format-patch origin/master..
+```
 
-## ask for approval
+This will print the file name of the formatted patch, which will be called
+something like `0001-external-add-myhostname.patch` (depending on your commmit
+message).  The contents of that should look something like this:
 
-join the #krebs channel on freenode.
-If you don't know anything about irc,  you can just use this webirc: https://webchat.freenode.net/#krebs
-If you are not known, introduce yourself, explain what you are doing and what you want to contribute. upload your patch to some pastebin (preferably https://paste.krebsco.de) or send it to spam@krebsco.de
+```patch
+From 75785902b71f03474c446694c5e1e25cd8c3ee23 Mon Sep 1700:00:00 2001
+From: myname <myname@mydomain>
+Date: Wed, 11 Sep 2019 11:34:44 +0200
+Subject: [PATCH] external: add myhostname
+
+---
+ krebs/3modules/external/default.nix | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/krebs/3modules/external/default.nix b/krebs/3modules/external/default.nix
+index aac67f2e..b6cdaebc 100644
+--- a/krebs/3modules/external/default.nix
++++ b/krebs/3modules/external/default.nix
+@@ -393,6 +393,20 @@ in {
+         };
+       };
+     };
++    myhostname = {
++      owner = config.krebs.users.myuser;
++      nets = {
++        retiolum = {
++          ip4.addr = "10.243.my.ip";
++          aliases = [ "myhostname.r" ];
++          tinc.pubkey = ''
++            -----BEGIN RSA PUBLIC KEY-----
++            ...
++            -----END RSA PUBLIC KEY-----
++          '';
++        };
++      };
++    };
+     qubasa = {
+       owner = config.krebs.users.qubasa;
+       nets = {
+@@ -693,6 +707,9 @@ in {
+       mail = "joerg@thalheim.io";
+       pubkey = ssh-for "Mic92";
+     };
++    myuser = {
++      mail = "myuser@mydomain";
++    };
+     qubasa = {
+       mail = "luis.nixos@gmail.com";
+     };
+-- 
+2.19.2
+```
+
+## ask for the patch to get merged
+
+Join the #krebs channel on freenode.
+If you don't know anything about IRC, you can just use this webirc: https://webchat.freenode.net/#krebs
+If you are not known, introduce yourself, explain what you are doing and what you want to contribute.
+Then send the formatted patch either sent via email to spam@krebsco.de, or
+upload it to some pastebin (preferably https://paste.krebsco.de) and share the
+link to the pasted patch in #krebs.
+Now some patience will be required, but you will soon receive confirmation or
+change requests for your patch, and it will get deployed to the super nodes.
+At this point your host will be able to join the network.
+For the impatient, pinging `lassulus` or `tv` might speed up the process,
+but usually we will act ASAP anyway.
 
 ## configure your nixos for retiolum
 

--- a/README.md
+++ b/README.md
@@ -12,22 +12,16 @@ For an example config look at `example.nix`
 
 ## generate your public/private keypair
 
-create a new folder somewhere on your machine
+Create a new directory somewhere on your machine:
 
 ```
 mkdir retiolum-cfg
 ```
 
-generate a private key
+Generate keypairs in that directory:
 
 ```
-openssl genrsa -out retiolum-cfg/retiolum.rsa_key.priv 4096
-```
-
-generate the public key from the private key
-
-```
-openssl rsa -in retiolum-cfg/retiolum.rsa_key.priv -pubout -out retiolum-cfg/retiolum.rsa_key.pub
+nix-shell -p tinc_pre --run 'tinc --config retiolum-cfg generate-keys 4096 </dev/null'
 ```
 
 ## add key to stockholm
@@ -99,6 +93,7 @@ index aac67f2e..b6cdaebc 100644
 +            -----BEGIN RSA PUBLIC KEY-----
 +            ...
 +            -----END RSA PUBLIC KEY-----
++            Ed25519PublicKey = ...
 +          '';
 +        };
 +      };

--- a/README.md
+++ b/README.md
@@ -14,34 +14,48 @@ For an example config look at `example.nix`
 
 create a new folder somewhere on your machine
 
-`mkdir retiolum-cfg`
+```
+mkdir retiolum-cfg
+```
 
 generate a private key
 
-`openssl genrsa -out retiolum-cfg/retiolum.rsa_key.priv 4096`
+```
+openssl genrsa -out retiolum-cfg/retiolum.rsa_key.priv 4096
+```
 
 generate the public key from the private key
 
-`openssl rsa -in retiolum-cfg/retiolum.rsa_key.priv -pubout -out retiolum-cfg/retiolum.rsa_key.pub`
+```
+openssl rsa -in retiolum-cfg/retiolum.rsa_key.priv -pubout -out retiolum-cfg/retiolum.rsa_key.pub
+```
 
 ## add key to stockholm
 
-`git clone https://cgit.krebsco.de/stockholm`
+```
+git clone https://cgit.krebsco.de/stockholm
+```
 
 choose an ipv4 address in the range of 10.243.0.0/16
 check if the ipv4 address is already used by anyone in stockholm:
 
-`git -C stockholm grep 10.243.my.ip`
+```
+git -C stockholm grep 10.243.my.ip
+```
 
 modify the default.nix in krebs/3modules/external
 
-`vim krebs/3modules/external/default.nix`
+```
+vim krebs/3modules/external/default.nix
+```
 
 add your host nix information to this file, please mind the alphabetical sorting
 
 now, create a patch out of your changes:
 
-`git diff > retiolum.patch`
+```
+git diff > retiolum.patch
+````
 
 ## ask for approval
 
@@ -60,6 +74,7 @@ import the example.nix (you can choose a better name, like retiolum.nix) in your
 configure your ipv4 and ipv6 addresses
 
 inside configuration.nix:
+
 ```
 imports = [
   /path/to/example.nix
@@ -72,5 +87,7 @@ networking.retiolum.ipv6 = "42:0:3c35::my:ip";
 
 ping some host on the network, for example blue.r
 
-`ping 10.243.0.77`
-`ping 42:0:ce16::b1ce`
+```
+ping 10.243.0.77
+ping 42:0:ce16::b1ce
+```


### PR DESCRIPTION
This PR updates the README to recommend the use of `git format-patch` instead of `git diff` for creating pull-requests.